### PR TITLE
Minions now Attack, Kill, and Win/Lose the game!

### DIFF
--- a/Assets/Resources/MinionStats.csv
+++ b/Assets/Resources/MinionStats.csv
@@ -1,3 +1,3 @@
-﻿MinionType,Health,AttackRange
-Warrior,80,1
-Archer,60,3
+﻿MinionType,Health,AttackRange,Damage
+Warrior,80,2,30
+Archer,60,4,20

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -260,7 +260,7 @@ GameObject:
   - component: {fileID: 1505544370}
   - component: {fileID: 1505544369}
   m_Layer: 0
-  m_Name: UnitSpawner
+  m_Name: PlayerSpawner
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -292,4 +292,48 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2104580773
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2104580775}
+  - component: {fileID: 2104580774}
+  m_Layer: 0
+  m_Name: EnemySpawner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2104580774
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2104580773}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8261bf3e9a2da14986550e6d66c402e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MinionPrefab: {fileID: 9163959790932554988, guid: e1d8dfa04b2471b4e97fb030a7757486, type: 3}
+--- !u!4 &2104580775
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2104580773}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -278,6 +278,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b8261bf3e9a2da14986550e6d66c402e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  UseAsPlayerSpawner: 1
   MinionPrefab: {fileID: 9163959790932554988, guid: e1d8dfa04b2471b4e97fb030a7757486, type: 3}
 --- !u!4 &1505544370
 Transform:
@@ -322,6 +323,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b8261bf3e9a2da14986550e6d66c402e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  UseAsPlayerSpawner: 0
   MinionPrefab: {fileID: 9163959790932554988, guid: e1d8dfa04b2471b4e97fb030a7757486, type: 3}
 --- !u!4 &2104580775
 Transform:

--- a/Assets/Scripts/Data/MinionLoaderXML.cs
+++ b/Assets/Scripts/Data/MinionLoaderXML.cs
@@ -20,6 +20,7 @@ namespace HoH_StateManagerTest.Data
                     stats.MinionType = row[0];
                     int.TryParse(row[1], out stats.Health);
                     int.TryParse(row[2], out stats.AttackRange);
+                    int.TryParse(row[3], out stats.Damage);
                     allStats.Add(stats);
                 }
             }

--- a/Assets/Scripts/Data/MinionXML.cs
+++ b/Assets/Scripts/Data/MinionXML.cs
@@ -5,5 +5,6 @@ namespace HoH_StateManagerTest.Data
         public string MinionType;
         public int Health;
         public int AttackRange;
+        public int Damage;
     }
 }

--- a/Assets/Scripts/Data/MinionXML.cs
+++ b/Assets/Scripts/Data/MinionXML.cs
@@ -1,4 +1,4 @@
-namespace HoH_StateManagerTest.Data
+﻿namespace HoH_StateManagerTest.Data
 {
     public struct MinionXML
     {

--- a/Assets/Scripts/States/BattleStateManager.cs
+++ b/Assets/Scripts/States/BattleStateManager.cs
@@ -1,3 +1,5 @@
+using HoH_StateManagerTest.Units;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.PlayerLoop;
@@ -10,22 +12,49 @@ namespace HoH_StateManagerTest.States
         [SerializeField] List<State> InterruptableStates;
 
         int _currentLoopedStateIndex = 0;
+        static bool bStatesInterrupted;
 
         void Start()
         {
-            var mockState = new SpawnNextWave(LoopedStateComplete);
+            var spawnPlayerUnits = new SpawnNextWave(LoopedStateComplete, UnitSpawner.player, "Spawn Player Units");
+            var spawnEnemyUnits = new SpawnNextWave(LoopedStateComplete, UnitSpawner.enemy, "Spawn Enemy Units");
+            var playerMinionsActivate = new MinionsActivate(LoopedStateComplete, UnitSpawner.player, "Player Units Activate 1/3");
+            var enemyMinionsActivate = new MinionsActivate(LoopedStateComplete, UnitSpawner.enemy, "Enemy Units Activate 1/3");
 
-            LoopedStates = new State[1];
-            LoopedStates[0] = mockState;
-            mockState.RunState();
+            LoopedStates = new State[8]; // quick and dirty hardcoding the list
+            LoopedStates[0] = spawnPlayerUnits;
+            LoopedStates[1] = spawnEnemyUnits;
+            LoopedStates[2] = playerMinionsActivate;
+            LoopedStates[3] = enemyMinionsActivate;
+            LoopedStates[4] = new MinionsActivate(LoopedStateComplete, UnitSpawner.player, "Player Units Activate 2/3"); ;
+            LoopedStates[5] = new MinionsActivate(LoopedStateComplete, UnitSpawner.enemy, "Enemy Units Activate 2/3");
+            LoopedStates[6] = new MinionsActivate(LoopedStateComplete, UnitSpawner.player, "Player Units Activate 3/3"); ;
+            LoopedStates[7] = new MinionsActivate(LoopedStateComplete, UnitSpawner.enemy, "Enemy Units Activate 3/3");
+
+            LoopedStates[0].RunState();
         }        
         
         public void LoopedStateComplete()
         {
+            if (bStatesInterrupted)
+                return;
+
             // log statements should be pushed to a Util class
-            Debug.Log($"<Color=green>{LoopedStates[_currentLoopedStateIndex].GetType().Name} Completed</Color>, calling Run State on the next Looped State");
+            Debug.Log($"<Color=green>{LoopedStates[_currentLoopedStateIndex].GetTitle()} Completed</Color>, calling Run State on the next Looped State");
             _currentLoopedStateIndex = (_currentLoopedStateIndex + 1) % LoopedStates.Length;
             LoopedStates[_currentLoopedStateIndex].RunState();
+        }
+
+        internal static void BattleWon()
+        {
+            bStatesInterrupted = true;
+            Debug.Log("<Color=red>Battle Won!</Color>");
+        }
+
+        internal static void BattleLost()
+        {
+            bStatesInterrupted = true;
+            Debug.Log("<Color=red>Battle Lost!</Color>");
         }
     }
 }

--- a/Assets/Scripts/States/BattleStateManager.cs
+++ b/Assets/Scripts/States/BattleStateManager.cs
@@ -1,4 +1,4 @@
-using HoH_StateManagerTest.Units;
+﻿using HoH_StateManagerTest.Units;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -9,27 +9,27 @@ namespace HoH_StateManagerTest.States
     public class BattleStateManager : MonoBehaviour
     {
         [SerializeField] State[] LoopedStates;
-        [SerializeField] List<State> InterruptableStates;
+        [SerializeField] readonly List<State> InterruptableStates;
 
-        int _currentLoopedStateIndex = 0;
+        int currentLoopedStateIndex = 0;
         static bool bStatesInterrupted;
 
         void Start()
         {
-            var spawnPlayerUnits = new SpawnNextWave(LoopedStateComplete, UnitSpawner.player, "Spawn Player Units");
-            var spawnEnemyUnits = new SpawnNextWave(LoopedStateComplete, UnitSpawner.enemy, "Spawn Enemy Units");
-            var playerMinionsActivate = new MinionsActivate(LoopedStateComplete, UnitSpawner.player, "Player Units Activate 1/3");
-            var enemyMinionsActivate = new MinionsActivate(LoopedStateComplete, UnitSpawner.enemy, "Enemy Units Activate 1/3");
+            var spawnPlayerUnits = new SpawnNextWave(LoopedStateComplete, UnitSpawner.PlayerSpawner, "Spawn Player Units");
+            var spawnEnemyUnits = new SpawnNextWave(LoopedStateComplete, UnitSpawner.EnemySpawner, "Spawn Enemy Units");
+            var playerMinionsActivate = new MinionsActivate(LoopedStateComplete, UnitSpawner.PlayerSpawner, "Player Units Activate 1/3");
+            var enemyMinionsActivate = new MinionsActivate(LoopedStateComplete, UnitSpawner.EnemySpawner, "Enemy Units Activate 1/3");
 
             LoopedStates = new State[8]; // quick and dirty hardcoding the list
             LoopedStates[0] = spawnPlayerUnits;
             LoopedStates[1] = spawnEnemyUnits;
             LoopedStates[2] = playerMinionsActivate;
             LoopedStates[3] = enemyMinionsActivate;
-            LoopedStates[4] = new MinionsActivate(LoopedStateComplete, UnitSpawner.player, "Player Units Activate 2/3"); ;
-            LoopedStates[5] = new MinionsActivate(LoopedStateComplete, UnitSpawner.enemy, "Enemy Units Activate 2/3");
-            LoopedStates[6] = new MinionsActivate(LoopedStateComplete, UnitSpawner.player, "Player Units Activate 3/3"); ;
-            LoopedStates[7] = new MinionsActivate(LoopedStateComplete, UnitSpawner.enemy, "Enemy Units Activate 3/3");
+            LoopedStates[4] = new MinionsActivate(LoopedStateComplete, UnitSpawner.PlayerSpawner, "Player Units Activate 2/3"); ;
+            LoopedStates[5] = new MinionsActivate(LoopedStateComplete, UnitSpawner.EnemySpawner, "Enemy Units Activate 2/3");
+            LoopedStates[6] = new MinionsActivate(LoopedStateComplete, UnitSpawner.PlayerSpawner, "Player Units Activate 3/3"); ;
+            LoopedStates[7] = new MinionsActivate(LoopedStateComplete, UnitSpawner.EnemySpawner, "Enemy Units Activate 3/3");
 
             LoopedStates[0].RunState();
         }        
@@ -40,9 +40,9 @@ namespace HoH_StateManagerTest.States
                 return;
 
             // log statements should be pushed to a Util class
-            Debug.Log($"<Color=green>{LoopedStates[_currentLoopedStateIndex].GetTitle()} Completed</Color>, calling Run State on the next Looped State");
-            _currentLoopedStateIndex = (_currentLoopedStateIndex + 1) % LoopedStates.Length;
-            LoopedStates[_currentLoopedStateIndex].RunState();
+            Debug.Log($"<Color=green>{LoopedStates[currentLoopedStateIndex].GetTitle()} Completed</Color>, calling Run State on the next Looped State");
+            currentLoopedStateIndex = (currentLoopedStateIndex + 1) % LoopedStates.Length;
+            LoopedStates[currentLoopedStateIndex].RunState();
         }
 
         internal static void BattleWon()

--- a/Assets/Scripts/States/MinionsActivate.cs
+++ b/Assets/Scripts/States/MinionsActivate.cs
@@ -8,9 +8,8 @@ namespace HoH_StateManagerTest.States
     internal class MinionsActivate : State
     {
         protected Action OnCompleteCallback;
-
-        UnitSpawner _targetSpawner;
-        string _title;
+        readonly UnitSpawner _targetSpawner;
+        readonly string _title;
 
         public MinionsActivate(Action onCompleteCallback, UnitSpawner spawner, string title)
         {
@@ -27,9 +26,8 @@ namespace HoH_StateManagerTest.States
 
             targetSpawner.MinionsActivate();
             await Task.Delay(TimeSpan.FromSeconds(2));
-            
-            if (OnCompleteCallback != null)
-                OnCompleteCallback();
+
+            OnCompleteCallback?.Invoke();
         }
 
         internal override void RunState()

--- a/Assets/Scripts/States/MinionsActivate.cs
+++ b/Assets/Scripts/States/MinionsActivate.cs
@@ -5,28 +5,28 @@ using System.Threading.Tasks;
 
 namespace HoH_StateManagerTest.States
 {
-    internal class SpawnNextWave : State
+    internal class MinionsActivate : State
     {
         protected Action OnCompleteCallback;
 
         UnitSpawner _targetSpawner;
-        private string _title;
+        string _title;
 
-        public SpawnNextWave(Action onCompleteCallback, UnitSpawner spawner, string title)
+        public MinionsActivate(Action onCompleteCallback, UnitSpawner spawner, string title)
         {
             _title = title;
             OnCompleteCallback = onCompleteCallback;
             _targetSpawner = spawner;
         }
         
-        private async void StartNextWave(CancellationToken token, UnitSpawner spawner)
+        private async void StartActivateMinions(CancellationToken token, UnitSpawner targetSpawner)
         {
             // Is it still good to use this thread
             if (token.IsCancellationRequested)
                 return;
 
-            spawner.SpawnMinions(UnityEngine.Random.Range(1,3));
-            await Task.Delay(TimeSpan.FromSeconds(1));
+            targetSpawner.MinionsActivate();
+            await Task.Delay(TimeSpan.FromSeconds(2));
             
             if (OnCompleteCallback != null)
                 OnCompleteCallback();
@@ -34,7 +34,7 @@ namespace HoH_StateManagerTest.States
 
         internal override void RunState()
         {
-            StartNextWave(ThreadingUtility.QuitToken, _targetSpawner);
+            StartActivateMinions(ThreadingUtility.QuitToken, _targetSpawner);
         }
 
         internal override string GetTitle()

--- a/Assets/Scripts/States/MinionsActivate.cs.meta
+++ b/Assets/Scripts/States/MinionsActivate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9712600d975e2194b80b61f151984710
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/States/SpawnNextWave.cs
+++ b/Assets/Scripts/States/SpawnNextWave.cs
@@ -8,9 +8,8 @@ namespace HoH_StateManagerTest.States
     internal class SpawnNextWave : State
     {
         protected Action OnCompleteCallback;
-
-        UnitSpawner _targetSpawner;
-        private string _title;
+        readonly UnitSpawner _targetSpawner;
+        private readonly string _title;
 
         public SpawnNextWave(Action onCompleteCallback, UnitSpawner spawner, string title)
         {
@@ -27,9 +26,8 @@ namespace HoH_StateManagerTest.States
 
             spawner.SpawnMinions(UnityEngine.Random.Range(1,3));
             await Task.Delay(TimeSpan.FromSeconds(1));
-            
-            if (OnCompleteCallback != null)
-                OnCompleteCallback();
+
+            OnCompleteCallback?.Invoke();
         }
 
         internal override void RunState()

--- a/Assets/Scripts/States/State.cs
+++ b/Assets/Scripts/States/State.cs
@@ -4,6 +4,7 @@ namespace HoH_StateManagerTest.States
 {
     public abstract class State
     {
+        internal abstract string GetTitle();
         internal abstract void RunState();
     }
 }

--- a/Assets/Scripts/Units/Minion.cs
+++ b/Assets/Scripts/Units/Minion.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using HoH_StateManagerTest.Data;
 using UnityEngine;
@@ -13,12 +14,45 @@ namespace HoH_StateManagerTest.Units
         internal int Health { get => _health; set => _health = value; }
         private int _attackRange;
         internal int AttackRange { get => _attackRange; set => _attackRange = value; }
+        private int _damage;
+        internal int Damage { get => _damage; set => _damage = value; }
 
-        public void SetStatsFromXML(MinionXML loadedData)
+        private UnitSpawner SpawnerRef;
+        public void SetStatsFromXML(MinionXML loadedData, UnitSpawner spawner)
         {
             MinionType = loadedData.MinionType;
             Health = loadedData.Health;
             AttackRange = loadedData.AttackRange;
+            Damage = loadedData.Damage;
+            SpawnerRef = spawner;
+        }
+
+        internal void TakeDamage(int damageAmount)
+        {
+            Health = Mathf.Max(0, Health - damageAmount);
+            if(Health == 0)
+            {
+                Debug.Log($"{MinionType} has taken {damageAmount} and is now dead.");
+                UnitSpawner.UnitDied(this);
+            }
+            else
+            {
+                Debug.Log($"{MinionType} has taken {damageAmount} and is now at {Health} health.");
+            }
+        }
+        internal virtual void Activate() // should be refactored, likely componentized
+        {
+            // using Attack range as a % chance to attack
+            bool UnitInRange = (UnityEngine.Random.Range(0, AttackRange)) > 0;
+
+            UnitSpawner targetSpawner = (SpawnerRef == UnitSpawner.player) ? UnitSpawner.enemy : UnitSpawner.player;
+            if (UnitInRange)
+            {
+                Debug.Log($"{MinionType} is attacking towards the {targetSpawner.name}");
+                UnitSpawner.DamageRandomUnit(this, targetSpawner);
+            }
+            else
+                Debug.Log($"{MinionType} could not find an enemy in range!");
         }
     }
 }

--- a/Assets/Scripts/Units/Minion.cs
+++ b/Assets/Scripts/Units/Minion.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using HoH_StateManagerTest.Data;
 using UnityEngine;
@@ -45,8 +45,8 @@ namespace HoH_StateManagerTest.Units
             // using Attack range as a % chance to attack
             bool UnitInRange = (UnityEngine.Random.Range(0, AttackRange)) > 0;
 
-            UnitSpawner targetSpawner = (SpawnerRef == UnitSpawner.player) ? UnitSpawner.enemy : UnitSpawner.player;
-            if (UnitInRange)
+            UnitSpawner targetSpawner = SpawnerRef?.GetOpposingSpawner();
+            if (UnitInRange && targetSpawner)
             {
                 Debug.Log($"{MinionType} is attacking towards the {targetSpawner.name}");
                 UnitSpawner.DamageRandomUnit(this, targetSpawner);

--- a/Assets/Scripts/Units/UnitSpawner.cs
+++ b/Assets/Scripts/Units/UnitSpawner.cs
@@ -1,4 +1,5 @@
 ﻿using HoH_StateManagerTest.Data;
+using HoH_StateManagerTest.States;
 using HoH_StateManagerTest.Units;
 using System.Collections.Generic;
 using UnityEngine;
@@ -8,16 +9,25 @@ namespace HoH_StateManagerTest.Units
 {
     public class UnitSpawner : MonoBehaviour
     {
-        public static UnitSpawner instance;
+        public static UnitSpawner player;
+        public static UnitSpawner enemy;
         [SerializeField] Minion MinionPrefab;
-
         List<MinionXML> MinionTypes;
         List<Minion> MinionHolder;
         void Awake()
         {
-            instance = this; // should be refactored, just an easy hack for now
+            if(enemy == null) // hack to set the two up
+                enemy = this;
+            else if(player == null)
+                player = this;
             MinionTypes = MinionLoaderXML.LoadData();
             MinionHolder = new List<Minion>();
+        }
+
+        internal void MinionsActivate()
+        {
+            foreach (Minion m in MinionHolder)
+                m.Activate();
         }
 
         public void SpawnMinions(int minionCount)
@@ -25,12 +35,42 @@ namespace HoH_StateManagerTest.Units
             Debug.Log($"Spawning {minionCount} random minions"); // logging and random numbers should come from a Util class
             for (int i = 0; i < minionCount; i++)
             {
-                Minion minion = Instantiate(MinionPrefab);
+                Minion minion = Instantiate(MinionPrefab, transform);
                 MinionXML type = MinionTypes[Random.Range(1, MinionTypes.Count)]; // start at 1 due to headers in the file
-                minion.SetStatsFromXML(type);
+                minion.SetStatsFromXML(type, this);
                 Debug.Log($"___New Minion___ Type: {minion.MinionType} Health: {minion.Health} Attack Range:{minion.AttackRange}");
                 MinionHolder.Add(minion);
             }
+        }
+
+        internal static void UnitDied(Minion minion)
+        {
+            enemy.MinionHolder.Remove(minion);
+            player.MinionHolder.Remove(minion);
+
+            if (enemy.MinionHolder.Count == 0)
+                BattleStateManager.BattleWon();
+            else if (player.MinionHolder.Count == 0)
+                BattleStateManager.BattleLost();
+
+            Destroy(minion.gameObject);
+        }
+
+        internal static void DamageRandomUnit(Minion attackingUnit, UnitSpawner targetPlayer)
+        {
+            Minion targetUnit = targetPlayer.GetRandomMinion();
+            if (targetUnit)
+                targetUnit.TakeDamage(attackingUnit.Damage);
+            else
+                Debug.Log("Info: No valid targets to attack");
+        }
+
+        public Minion GetRandomMinion()
+        {
+            if (MinionHolder.Count == 0)
+                return null;
+
+            return MinionHolder[Random.Range(0, MinionHolder.Count)];
         }
     }
 }

--- a/Assets/Scripts/Util/ThreadingUtility.cs
+++ b/Assets/Scripts/Util/ThreadingUtility.cs
@@ -1,6 +1,6 @@
 ﻿/*******
 This makes it easy to see if the app is exiting so you can force your thread logic to stop - Ian L 8/3/22
-Found online, for more info Post 9 here: https://forum.unity.com/threads/non-stopping-async-method-after-in-editor-game-is-stopped.558283/
+Found online, Post #9: https://forum.unity.com/threads/non-stopping-async-method-after-in-editor-game-is-stopped.558283/
 *****/
 
 using System.Threading;


### PR DESCRIPTION
Having fun so extending some functionality.
- New State: Minions Activate (loops through one of the teams minions and calls Active on each one)
- Minions now have a default Attack Action that uses Attack Range and Damage
- On Unit Death we check for any End Game States (win/lose) and set the loopedStates to stop if we did